### PR TITLE
Always fetch externals via git in get_externals.bat

### DIFF
--- a/PCbuild/get_externals.bat
+++ b/PCbuild/get_externals.bat
@@ -64,12 +64,9 @@ set libraries=%libraries%                                       zlib-1.2.13
 for %%e in (%libraries%) do (
     if exist "%EXTERNALS_DIR%\%%e" (
         echo.%%e already exists, skipping.
-    ) else if NOT DEFINED PYTHON (
+    ) else (
         echo.Fetching %%e with git...
         git clone --depth 1 https://github.com/%ORG%/cpython-source-deps --branch %%e "%EXTERNALS_DIR%\%%e"
-    ) else (
-        echo.Fetching %%e...
-        %PYTHON% -E "%PCBUILD%\get_external.py" -O %ORG% -e "%EXTERNALS_DIR%" %%e
     )
 )
 
@@ -84,12 +81,9 @@ if NOT "%IncludeSSLSrc%"=="false"  set binaries=%binaries% nasm-2.11.06
 for %%b in (%binaries%) do (
     if exist "%EXTERNALS_DIR%\%%b" (
         echo.%%b already exists, skipping.
-    ) else if NOT DEFINED PYTHON (
+    ) else (
         echo.Fetching %%b with git...
         git clone --depth 1 https://github.com/%ORG%/cpython-bin-deps --branch %%b "%EXTERNALS_DIR%\%%b"
-    ) else (
-        echo.Fetching %%b...
-        %PYTHON% -E "%PCBUILD%\get_external.py" -b -O %ORG% -e "%EXTERNALS_DIR%" %%b
     )
 )
 


### PR DESCRIPTION
Avoids the get_external.py script which has issues using SSL on Windows.
