### PR TITLE
Upgrade to V4 Arcade publishing

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
    <PropertyGroup>
-      <PublishingVersion>3</PublishingVersion>
+      <PublishingVersion>4</PublishingVersion>
    </PropertyGroup>
 </Project>

--- a/eng/azure-pipelines-public.yml
+++ b/eng/azure-pipelines-public.yml
@@ -23,7 +23,6 @@ stages:
     parameters:
       enablePublishBuildArtifacts: true
       enablePublishBuildAssets: true
-      enablePublishUsingPipelines: true
       jobs:
 
       ############ MACOS BUILD ############

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -43,11 +43,12 @@ extends:
         parameters:
           enablePublishBuildArtifacts: true
           enablePublishBuildAssets: true
-          enablePublishUsingPipelines: true
+          publishingVersion: 4
           jobs:
 
           ############ MACOS x64 BUILD ############
           - job: Build_macOS_x64
+            enablePublishing: true
             displayName: macOS_x64
             timeoutInMinutes: 120
             pool:
@@ -79,6 +80,7 @@ extends:
 
           ############ MACOS arm64 BUILD ############
           - job: Build_macOS_arm64
+            enablePublishing: true
             displayName: macOS_arm64
             timeoutInMinutes: 120
             pool:
@@ -110,6 +112,7 @@ extends:
 
           ############ WINDOWS x64 BUILD ############
           - job: Build_Windows_x64
+            enablePublishing: true
             displayName: Windows_x64
             timeoutInMinutes: 120
             pool:
@@ -131,6 +134,7 @@ extends:
 
           ############ WINDOWS arm64 BUILD ############
           - job: Build_Windows_arm64
+            enablePublishing: true
             displayName: Windows_arm64
             timeoutInMinutes: 120
             pool:
@@ -153,6 +157,7 @@ extends:
     ############ POST BUILD ARCADE LOGIC ############
     - template: /eng/common/templates-official/post-build/post-build.yml@self
       parameters:
+        publishingInfraVersion: 4
         enableSourceLinkValidation: false
         enableSigningValidation: false
         enableSymbolValidation: false

--- a/eng/common-variables.yml
+++ b/eng/common-variables.yml
@@ -24,6 +24,5 @@ variables:
     - group: DotNet-HelixApi-Access
     - name: _InternalBuildArgs
       value: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName)
-        /p:DotNetPublishUsingPipelines=true
         /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
         /p:OfficialBuildId=$(BUILD.BUILDNUMBER)


### PR DESCRIPTION
Related to dotnet/arcade#16697.

This updates the repo from Arcade V3 publishing to V4 by:
- setting PublishingVersion to 4
- switching pipeline jobs to V4 publishingVersion/enablePublishing
- removing legacy V3 publish toggles